### PR TITLE
Allow custom OpenSSL installation.

### DIFF
--- a/utilfuncs.py
+++ b/utilfuncs.py
@@ -350,6 +350,7 @@ def guess_openssl_location(conf):
         conf,
         [
             '{options.openssl}/build/{options.dest_platform}/include',
+            '{options.openssl}/include',
             'dependencies/{options.dest_platform}/openssl/include',
         ],
         message='Specify --openssl')
@@ -358,6 +359,7 @@ def guess_openssl_location(conf):
         conf,
         [
             '{options.openssl}/build/{options.dest_platform}/lib',
+            '{options.openssl}/lib',
             'dependencies/{options.dest_platform}/openssl/lib',
         ],
         message='Specify --openssl')


### PR DESCRIPTION
This allows to either use system OpenSSL or manually compiled one from vanilla sources.
